### PR TITLE
Add a panel to the Resque web-ui

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -8,6 +8,14 @@ mechanism for recording/sending the metrics to your favorite tool (AKA statsd/gr
 
     gem install resque-metrics
 
+If you are using bundler add this to your Gemfile
+
+    gem "resque-metrics"
+
+And if you want the web-ui extensions
+
+    gem "resque-metrics", :require => "resque-metrics/server"
+
 == Usage
 
 Given a job, extend the job class with Resque::Metrics.

--- a/lib/resque-metrics.rb
+++ b/lib/resque-metrics.rb
@@ -1,1 +1,6 @@
 require 'resque/metrics'
+require 'resque-metrics/server'
+
+Resque::Server.class_eval do
+  include Resque::Metrics::Server
+end

--- a/lib/resque-metrics.rb
+++ b/lib/resque-metrics.rb
@@ -1,6 +1,1 @@
 require 'resque/metrics'
-require 'resque-metrics/server'
-
-Resque::Server.class_eval do
-  include Resque::Metrics::Server
-end

--- a/lib/resque-metrics/server.rb
+++ b/lib/resque-metrics/server.rb
@@ -1,4 +1,5 @@
 require 'resque/server'
+require 'resque/metrics'
 
 # Extend Resque::Server to add tabs
 module Resque
@@ -38,4 +39,8 @@ module Resque
       Resque::Server.tabs << 'Metrics'
     end
   end
+end
+
+Resque::Server.class_eval do
+  include Resque::Metrics::Server
 end

--- a/lib/resque-metrics/server.rb
+++ b/lib/resque-metrics/server.rb
@@ -1,0 +1,41 @@
+require 'resque/server'
+
+# Extend Resque::Server to add tabs
+module Resque
+  module Metrics
+    module Server
+      def self.included(base)
+        base.class_eval do
+          helpers do
+            # reads a 'local' template file.
+            def local_template(path)
+              # Is there a better way to specify alternate template locations with sinatra?
+              File.read(File.join(File.dirname(__FILE__), "server/views/#{path}"))
+            end
+
+            def metrics_formatted_ms(milliseconds)
+              seconds = milliseconds / 1000
+              hours = (seconds / 3600).floor
+              minutes = (seconds % 3600) / 60
+              seconds = seconds % 60
+
+              str = []
+              str << "#{hours} hours" if hours > 0
+              str << "#{minutes} minutes" if minutes > 0
+              str << "#{seconds} seconds" if seconds > 0
+              str << "Less than a second" if milliseconds < 1000
+
+              str.join(" ")
+            end
+          end
+
+          get "/metrics" do
+            erb local_template("metrics.erb")
+          end
+        end
+      end
+
+      Resque::Server.tabs << 'Metrics'
+    end
+  end
+end

--- a/lib/resque-metrics/server/views/metrics.erb
+++ b/lib/resque-metrics/server/views/metrics.erb
@@ -8,8 +8,10 @@
     </tr>
 
     <% resque.queues.each do |queue| %>
-      <td class="queue"><a href="<%=u "queues/#{queue}" %>"><%= queue %></a></td>
-      <td class="size"><%= Resque::Metrics.total_job_count_by_queue(queue) %></td>
+      <tr>
+        <td class="queue"><a href="<%=u "queues/#{queue}" %>"><%= queue %></a></td>
+        <td class="size"><%= Resque::Metrics.total_job_count_by_queue(queue) %></td>
+      </tr>
     <% end %>
 
     <tr class="failed">
@@ -27,8 +29,10 @@
     </tr>
 
     <% resque.queues.each do |queue| %>
-      <td class="queue"><a href="<%=u "queues/#{queue}" %>"><%= queue %></a></td>
-      <td class="size"><%= metrics_formatted_ms(Resque::Metrics.avg_job_time_by_queue(queue)) %></td>
+      <tr>
+        <td class="queue"><a href="<%=u "queues/#{queue}" %>"><%= queue %></a></td>
+        <td class="size"><%= metrics_formatted_ms(Resque::Metrics.avg_job_time_by_queue(queue)) %></td>
+      </tr>
     <% end %>
 
     <tr class="failed">
@@ -46,8 +50,10 @@
     </tr>
 
     <% resque.queues.each do |queue| %>
-      <td class="queue"><a href="<%=u "queues/#{queue}" %>"><%= queue %></a></td>
-      <td class="size"><%= metrics_formatted_ms(Resque::Metrics.total_job_time_by_queue(queue)) %></td>
+      <tr>
+        <td class="queue"><a href="<%=u "queues/#{queue}" %>"><%= queue %></a></td>
+        <td class="size"><%= metrics_formatted_ms(Resque::Metrics.total_job_time_by_queue(queue)) %></td>
+      </tr>
     <% end %>
 
     <tr class="failed">

--- a/lib/resque-metrics/server/views/metrics.erb
+++ b/lib/resque-metrics/server/views/metrics.erb
@@ -1,0 +1,58 @@
+<h1>All your metrics are belong to Resque</h1>
+
+<table class="queues">
+  <tbody>
+    <tr>
+      <th>Queue</th>
+      <th>Jobs completed</th>
+    </tr>
+
+    <% resque.queues.each do |queue| %>
+      <td class="queue"><a href="<%=u "queues/#{queue}" %>"><%= queue %></a></td>
+      <td class="size"><%= Resque::Metrics.total_job_count_by_queue(queue) %></td>
+    <% end %>
+
+    <tr class="failed">
+      <td class="queue failed"></td>
+      <td class="size"><%= Resque::Metrics.total_job_count %></td>
+    </tr>
+  </tbody>
+</table>
+
+<table class="queues">
+  <tbody>
+    <tr>
+      <th>Queue</th>
+      <th>Average job time</th>
+    </tr>
+
+    <% resque.queues.each do |queue| %>
+      <td class="queue"><a href="<%=u "queues/#{queue}" %>"><%= queue %></a></td>
+      <td class="size"><%= metrics_formatted_ms(Resque::Metrics.avg_job_time_by_queue(queue)) %></td>
+    <% end %>
+
+    <tr class="failed">
+      <td class="queue failed"></td>
+      <td class="size"><%= metrics_formatted_ms(Resque::Metrics.avg_job_time) %></td>
+    </tr>
+  </tbody>
+</table>
+
+<table class="queues">
+  <tbody>
+    <tr>
+      <th>Queue</th>
+      <th>Total job time</th>
+    </tr>
+
+    <% resque.queues.each do |queue| %>
+      <td class="queue"><a href="<%=u "queues/#{queue}" %>"><%= queue %></a></td>
+      <td class="size"><%= metrics_formatted_ms(Resque::Metrics.total_job_time_by_queue(queue)) %></td>
+    <% end %>
+
+    <tr class="failed">
+      <td class="queue failed"></td>
+      <td class="size"><%= metrics_formatted_ms(Resque::Metrics.total_job_time) %></td>
+    </tr>
+  </tbody>
+</table>


### PR DESCRIPTION
I've added a Metrics tab to the Resque web-ui and made it only load if required in the Gemfile.

![Screenshot of web-ui in action](http://f.cl.ly/items/3Z2P2g1u3R0001081I44/Screen%20Shot%202012-05-05%20at%2010.26.44.png)
