### PR TITLE
Use boxen-provided redis if available

### DIFF
--- a/test/helper.rb
+++ b/test/helper.rb
@@ -20,36 +20,42 @@ require 'resque/metrics'
 # make sure we can run redis
 #
 
-if !system("which redis-server")
-  puts '', "** can't find `redis-server` in your path"
-  puts "** try running `sudo rake install`"
-  abort ''
-end
-
-#
-# start our own redis when the tests start,
-# kill it when they end
-#
-
-at_exit do
-  next if $!
-
-  if defined?(MiniTest)
-    exit_code = MiniTest::Unit.new.run(ARGV)
-  else
-    exit_code = Test::Unit::AutoRunner.run
+if ENV['BOXEN_REDIS_PORT']
+  redis_port = ENV['BOXEN_REDIS_PORT']
+else
+  if !system("which redis-server")
+    puts '', "** can't find `redis-server` in your path"
+    puts "** try running `sudo rake install`"
+    abort ''
   end
 
-  pid = `ps -e -o pid,command | grep [r]edis-test`.split(" ")[0]
-  puts "Killing test redis server..."
-  Process.kill("KILL", pid.to_i)
-  FileUtils.rm_rf("#{dir}/dump.rdb")
-  exit exit_code
-end
+  #
+  # start our own redis when the tests start,
+  # kill it when they end
+  #
 
-puts "Starting redis for testing at localhost:9736..."
-`redis-server #{dir}/redis-test.conf`
-Resque.redis = 'localhost:9736:2'
+  at_exit do
+    next if $!
+
+    if defined?(MiniTest)
+      exit_code = MiniTest::Unit.new.run(ARGV)
+    else
+      exit_code = Test::Unit::AutoRunner.run
+    end
+
+    pid = `ps -e -o pid,command | grep [r]edis-test`.split(" ")[0]
+    puts "Killing test redis server..."
+    Process.kill("KILL", pid.to_i)
+    FileUtils.rm_rf("#{dir}/dump.rdb")
+    exit exit_code
+  end
+
+  puts "Starting redis for testing at localhost:9736..."
+  `redis-server #{dir}/redis-test.conf`
+
+  redis_port = 9736
+end
+Resque.redis = "localhost:#{redis_port}:2"
 
 class SomeJob
   extend Resque::Metrics


### PR DESCRIPTION
This simply checks `BOXEN_REDIS_PORT` in the environment, and tries to connect to that instead of starting up it's own redis.

Fixes https://github.com/quirkey/resque-metrics/issues/4
