### PR TITLE
Track metrics for failure

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -23,8 +23,8 @@ Given a job, extend the job class with Resque::Metrics.
 
     end
 
-By default this will record the total job count, the total count of jobs enqueued, the total time the jobs took, the avg time the jobs took. It 
-will also record each of these per-queue and per-bob class. So for the job above it will record values and you will be able to fetch them
+By default this will record the total job count, the total count of jobs enqueued, the total time the jobs took, the avg time the jobs took. It will also record the total number of job failures. 
+These metrics are also tracked by queue and job class. So for the job above, it will record values and you will be able to fetch them
 with module methods:
 
     Resque::Metrics.total_job_count #=> 1
@@ -36,6 +36,9 @@ with module methods:
     Resque::Metrics.avg_job_time #=> 1000
     Resque::Metrics.avg_job_time_by_job(SomeJob) #=> 1000
     Resque::Metrics.avg_job_time_by_queue(:jobs) #=> 1000
+    Resque::Metrics.failed_job_count #=> 1
+    Resque::Metrics.failed_job_count_by_job(SomeJob) #=> 0
+    Resque::Metrics.failed_job_count_by_queue(:jobs) #=> 0
 
 All values are recorded and returned as integers. For times, values are in milliseconds.
 
@@ -64,7 +67,7 @@ Latest Resque is required for fork recording to work.
 Resque::Metrics also has a simple callback/hook system so you can send data to your favorite agent. All hooks are passed the job class,
 the queue, and the time of the metric. 
 
-    # Also `on_job_fork` and `on_job_enqueue`
+    # Also `on_job_fork`, `on_job_enqueue`, and `on_job_failure` (`on_job_failure does not include `time`)
     Resque::Metric.on_job_complete do |job_class, queue, time|
       # send to your metrics agent
       Statsd.timing "resque.#{job_class}.complete_time", time

--- a/README.rdoc
+++ b/README.rdoc
@@ -67,13 +67,8 @@ Latest Resque is required for fork recording to work.
 Resque::Metrics also has a simple callback/hook system so you can send data to your favorite agent. All hooks are passed the job class,
 the queue, and the time of the metric. 
 
-<<<<<<< HEAD
     # Also `on_job_fork`, `on_job_enqueue`, and `on_job_failure` (`on_job_failure does not include `time`)
-    Resque::Metric.on_job_complete do |job_class, queue, time|
-=======
-    # Also `on_job_fork` and `on_job_enqueue`
     Resque::Metrics.on_job_complete do |job_class, queue, time|
->>>>>>> master
       # send to your metrics agent
       Statsd.timing "resque.#{job_class}.complete_time", time
       Statsd.increment "resque.#{job_class}.complete"

--- a/lib/resque/metrics.rb
+++ b/lib/resque/metrics.rb
@@ -136,7 +136,7 @@ module Resque
         increment_metric "failed_job_count:job:#{job_class}"
       end
       
-      run_callback(:on_job_failure, job_class, queue, time)
+      run_callback(:on_job_failure, job_class, queue)
     end
 
     def self.multi(&block)

--- a/lib/resque/metrics.rb
+++ b/lib/resque/metrics.rb
@@ -131,9 +131,9 @@ module Resque
       queue = Resque.queue_from_class(job_class)
       
       multi do
-        increment_metric "failure_count"
-        increment_metric "failure_count:queue:#{queue}"
-        increment_metric "failure_count:job:#{job_class}"
+        increment_metric "failed_job_count"
+        increment_metric "failed_job_count:queue:#{queue}"
+        increment_metric "failed_job_count:job:#{job_class}"
       end
       
       run_callback(:on_job_failure, job_class, queue, time)
@@ -206,6 +206,18 @@ module Resque
 
     def self.total_job_count_by_job(job)
       get_metric "job_count:job:#{job}"
+    end
+
+    def self.failed_job_count
+      get_metric "failed_job_count"
+    end
+
+    def self.failed_job_count_by_queue(queue)
+      get_metric "failed_job_count:queue:#{queue}"
+    end
+
+    def self.failed_job_count_by_job(job)
+      get_metric "failed_job_count:job:#{job}"
     end
 
     def self.total_payload_size

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -67,3 +67,13 @@ class SomeJob
   end
 
 end
+
+class FailureJob
+  extend Resque::Metrics
+
+  @queue = :jobs
+
+  def self.perform
+    fail "nope"
+  end
+end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -74,6 +74,6 @@ class FailureJob
   @queue = :jobs
 
   def self.perform
-    fail "nope"
+    raise "failing lol"
   end
 end

--- a/test/test_resque-metrics.rb
+++ b/test/test_resque-metrics.rb
@@ -59,7 +59,7 @@ class TestResqueMetrics < MiniTest::Unit::TestCase
     assert Resque::Metrics.avg_job_time_by_job(SomeJob) > 0
   end
 
-  def test_should_call_callbacks
+  def test_should_call_job_complete_callbacks
     recorded = []
     recorded_count = 0
     Resque::Metrics.on_job_complete do |klass, queue, time|

--- a/test/test_resque-metrics.rb
+++ b/test/test_resque-metrics.rb
@@ -86,14 +86,12 @@ class TestResqueMetrics < MiniTest::Unit::TestCase
   end
 
   def test_should_call_job_failure_callbacks
-    skip "doesn't seem to record yet"
-
     recorded = []
     recorded_count = 0
-    Resque::Metrics.on_job_failure do |klass, queue, time|
-      recorded << {:klass => klass, :queue => queue, :time => time}
+    Resque::Metrics.on_job_failure do |klass, queue|
+      recorded << {:klass => klass, :queue => queue}
     end
-    Resque::Metrics.on_job_failure do |klass, queue, time|
+    Resque::Metrics.on_job_failure do |klass, queue|
       recorded_count += 1
     end
 
@@ -104,7 +102,6 @@ class TestResqueMetrics < MiniTest::Unit::TestCase
     assert_equal 3, recorded.length
     assert_equal FailureJob, recorded[0][:klass]
     assert_equal :jobs, recorded[0][:queue]
-    assert recorded[0][:time] > 0
     assert_equal 3, recorded_count
   end
 

--- a/test/test_resque-metrics.rb
+++ b/test/test_resque-metrics.rb
@@ -91,7 +91,7 @@ class TestResqueMetrics < MiniTest::Unit::TestCase
     recorded = []
     recorded_count = 0
     Resque::Metrics.on_job_failure do |klass, queue, time|
-      recorded << [klass, queue, time]
+      recorded << {:klass => klass, :queue => queue, :time => time}
     end
     Resque::Metrics.on_job_failure do |klass, queue, time|
       recorded_count += 1
@@ -102,9 +102,9 @@ class TestResqueMetrics < MiniTest::Unit::TestCase
     fail_job
 
     assert_equal 3, recorded.length
-    assert_equal FailureJob, recorded[0][0]
-    assert_equal :jobs, recorded[0][1]
-    assert recorded[0][2] > 0
+    assert_equal FailureJob, recorded[0][:klass]
+    assert_equal :jobs, recorded[0][:queue]
+    assert recorded[0][:time] > 0
     assert_equal 3, recorded_count
   end
 

--- a/test/test_resque-metrics.rb
+++ b/test/test_resque-metrics.rb
@@ -47,6 +47,12 @@ class TestResqueMetrics < MiniTest::Unit::TestCase
     assert Resque::Metrics.total_job_count_by_job(SomeJob) > 0
   end
 
+  def test_should_record_failed_job_count
+    assert Resque::Metrics.failed_job_count > 0, "Expected #{Resque::Metrics.failed_job_count} to be > 0, but wasn't"
+    assert Resque::Metrics.failed_job_count_by_queue(:jobs) > 0
+    assert Resque::Metrics.failed_job_count_by_job(FailureJob) > 0
+  end
+
   def test_should_record_payload_size
     assert Resque::Metrics.total_payload_size > 0
     assert Resque::Metrics.total_payload_size_by_queue(:jobs) > 0
@@ -75,7 +81,7 @@ class TestResqueMetrics < MiniTest::Unit::TestCase
     assert_equal 2, recorded.length
     assert_equal SomeJob, recorded[0][0]
     assert_equal :jobs, recorded[0][1]
-    assert recorded[0][2] > 0
+    assert recorded[0][2] > 0, "Expected #{recorded[0][2]} to be > 0, but wasn't"
     assert_equal 2, recorded_count
   end
 

--- a/test/test_resque-metrics.rb
+++ b/test/test_resque-metrics.rb
@@ -69,7 +69,7 @@ class TestResqueMetrics < MiniTest::Unit::TestCase
     recorded = []
     recorded_count = 0
     Resque::Metrics.on_job_complete do |klass, queue, time|
-      recorded << [klass, queue, time]
+      recorded << {:klass => klass, :queue => queue, :time => time }
     end
     Resque::Metrics.on_job_complete do |klass, queue, time|
       recorded_count += 1
@@ -79,9 +79,9 @@ class TestResqueMetrics < MiniTest::Unit::TestCase
     work_job
 
     assert_equal 2, recorded.length
-    assert_equal SomeJob, recorded[0][0]
-    assert_equal :jobs, recorded[0][1]
-    assert recorded[0][2] > 0, "Expected #{recorded[0][2]} to be > 0, but wasn't"
+    assert_equal SomeJob, recorded[0][:klass]
+    assert_equal :jobs, recorded[0][:queue]
+    assert recorded[0][:time] > 0, "Expected #{recorded[0][:time]} to be > 0, but wasn't"
     assert_equal 2, recorded_count
   end
 

--- a/test/test_resque-metrics.rb
+++ b/test/test_resque-metrics.rb
@@ -79,6 +79,29 @@ class TestResqueMetrics < MiniTest::Unit::TestCase
     assert_equal 2, recorded_count
   end
 
+  def test_should_call_job_failure_callbacks
+    skip "doesn't seem to record yet"
+
+    recorded = []
+    recorded_count = 0
+    Resque::Metrics.on_job_failure do |klass, queue, time|
+      recorded << [klass, queue, time]
+    end
+    Resque::Metrics.on_job_failure do |klass, queue, time|
+      recorded_count += 1
+    end
+
+    fail_job
+    fail_job
+    fail_job
+
+    assert_equal 3, recorded.length
+    assert_equal FailureJob, recorded[0][0]
+    assert_equal :jobs, recorded[0][1]
+    assert recorded[0][2] > 0
+    assert_equal 3, recorded_count
+  end
+
   private
 
   def work_job


### PR DESCRIPTION
I think tracking failures is pretty important. It's definitely one of the more actionable metrics (_oh snap, failures increased over the past hour, better look into it_).

This adds a `on_job_failure` hook to `Resque::Metrics`. I tried to remain in line with the other hooks as much as possible, but the main difference was I didn't see an obvious way to track time since exception, and also I don't think it'd be as useful even if I included it.

I've updated the README with details, and included additional tests to confirm functionality. I ended up including https://github.com/quirkey/resque-metrics/pull/5 in this so I could get tests working locally.
