### PR TITLE
Fix statsd metric name for payload_size metrics

### DIFF
--- a/lib/resque/metrics/backends/statsd.rb
+++ b/lib/resque/metrics/backends/statsd.rb
@@ -38,9 +38,9 @@ module Resque
             queue_or_job_name = $2
             key = if queue_or_job && queue_or_job_name
                     # ie resque.complete.queue.high.count, resque.failed.job.Index.timing
-                    "#{metric_prefix}.payload_size.#{queue_or_job}.#{queue_or_job_name}.#{time_or_count}"
+                    "#{metric_prefix}.payload_size.#{queue_or_job}.#{queue_or_job_name}.count"
                   else
-                    "#{metric_prefix}.payload_size.#{time_or_count}"
+                    "#{metric_prefix}.payload_size.count"
                   end
             statsd.increment key, by
           else


### PR DESCRIPTION
Metrics for `payload_size` seem to be coming through to statsd incorrectly. Specifically, the names come through with a trailing `.` (e.g., `application.resque.payload_size.` ).

This fixes that, by always using the word `count` at the end of the metric name. (These lines look like they've come from further up, but in these instances, `time_or_count` is never set, and so the interpolated string ends with a `.`; and these values should always be `count`-like, and not `time`.)
